### PR TITLE
feat: database sharing ergonomics

### DIFF
--- a/vectorscan-rs/Cargo.toml
+++ b/vectorscan-rs/Cargo.toml
@@ -13,6 +13,9 @@ repository.workspace = true
 rust-version.workspace = true
 
 [features]
+# Arc-wrapped database and owned scanner types for cross-thread sharing.
+shared = []
+
 # Specialize the build of Vectorscan to use available SIMD instructions on the build system's CPU.
 # This will result in binary that is not portable to other CPUs.
 simd_specialization = ["vectorscan-rs-sys/simd_specialization"]

--- a/vectorscan-rs/src/lib.rs
+++ b/vectorscan-rs/src/lib.rs
@@ -3,6 +3,8 @@
 
 mod error;
 mod native;
+#[cfg(feature = "shared")]
+pub mod shared;
 mod wrapper;
 
 pub use error::{AsResult, Error, HyperscanErrorCode};

--- a/vectorscan-rs/src/native.rs
+++ b/vectorscan-rs/src/native.rs
@@ -277,14 +277,14 @@ impl<'ss> StreamScanner<'ss> {
 ///
 /// This serves to wrap a Rust closure with a layer of indirection, so it can be referred to
 /// through a `void *` pointer in C.
-struct Context<F>
+pub(crate) struct Context<F>
 where
     F: FnMut(u32, u64, u64, u32) -> Scan,
 {
-    on_match: F,
+    pub(crate) on_match: F,
 }
 
-unsafe extern "C" fn on_match_trampoline<F>(
+pub(crate) unsafe extern "C" fn on_match_trampoline<F>(
     id: c_uint,
     from: c_ulonglong,
     to: c_ulonglong,

--- a/vectorscan-rs/src/shared.rs
+++ b/vectorscan-rs/src/shared.rs
@@ -1,0 +1,192 @@
+//! Arc-wrapped database and owned scanner for sharing a compiled database across threads
+//! or storing a scanner alongside its database in a struct.
+
+use foreign_types::ForeignType;
+use std::ffi::c_void;
+use std::sync::Arc;
+use vectorscan_rs_sys as hs;
+
+use super::native::{on_match_trampoline, Context, Scan};
+use super::{wrapper, AsResult, Error, HyperscanErrorCode, Pattern, ScanMode};
+
+/// A block-mode database whose compiled data is reference-counted with [`Arc`]
+/// and can be shared across threads or stored in structs avoiding self-referential problems.
+#[derive(Clone, Debug)]
+pub struct SharedBlockDatabase {
+    inner: Arc<wrapper::Database>,
+}
+
+impl SharedBlockDatabase {
+    /// Create a new database with the given patterns
+    pub fn new(patterns: Vec<Pattern>) -> Result<Self, Error> {
+        let inner = wrapper::Database::new(patterns, ScanMode::BLOCK)?;
+        Ok(Self {
+            inner: Arc::new(inner),
+        })
+    }
+
+    /// Create a new scanner from this database
+    pub fn create_scanner(&self) -> Result<OwnedBlockScanner, Error> {
+        OwnedBlockScanner::new(self)
+    }
+
+    /// Get the size in bytes of the database
+    pub fn size(&self) -> Result<usize, Error> {
+        self.inner.size()
+    }
+}
+
+/// A block-mode scanner that owns its scratch space and an [`Arc`] reference to the database.
+///
+/// Unlike [`BlockScanner`](super::BlockScanner), this type has no lifetime parameter,
+/// making it easy to store in structs or move between threads.
+#[derive(Clone, Debug)]
+pub struct OwnedBlockScanner {
+    scratch: wrapper::Scratch,
+    db: Arc<wrapper::Database>,
+}
+
+impl OwnedBlockScanner {
+    /// Create a new scanner with the given database
+    pub fn new(db: &SharedBlockDatabase) -> Result<Self, Error> {
+        Ok(Self {
+            scratch: wrapper::Scratch::new(&db.inner)?,
+            db: Arc::clone(&db.inner),
+        })
+    }
+
+    /// Scan the input using the given callback function
+    ///
+    /// See [`BlockScanner::scan`](super::BlockScanner::scan) for callback details.
+    pub fn scan<F>(&mut self, data: &[u8], on_match: F) -> Result<Scan, Error>
+    where
+        F: FnMut(u32, u64, u64, u32) -> Scan,
+    {
+        let mut context = Context { on_match };
+
+        let res = unsafe {
+            hs::hs_scan(
+                self.db.as_ptr(),
+                data.as_ptr() as *const _,
+                data.len() as u32,
+                0,
+                self.scratch.as_ptr(),
+                Some(on_match_trampoline::<F>),
+                &mut context as *mut _ as *mut c_void,
+            )
+            .ok()
+        };
+
+        match res {
+            Ok(_) => Ok(Scan::Continue),
+            Err(err) => match err {
+                Error::Hyperscan(HyperscanErrorCode::ScanTerminated, _) => Ok(Scan::Terminate),
+                err => Err(err),
+            },
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{Flag, Pattern, Scan};
+
+    #[test]
+    fn shared_block_scanning_basic() -> Result<(), Error> {
+        let patterns = vec![Pattern::new(b"hello".to_vec(), Flag::default(), None)];
+        let db = SharedBlockDatabase::new(patterns)?;
+        let mut scanner = db.create_scanner()?;
+
+        let mut matches = Vec::new();
+        scanner.scan(b"hello hello", |id, from, to, flags| {
+            matches.push((id, from, to, flags));
+            Scan::Continue
+        })?;
+        assert_eq!(matches.as_slice(), &[(0, 0, 5, 0), (0, 0, 11, 0)]);
+
+        Ok(())
+    }
+
+    #[test]
+    fn scanner_outlives_database() -> Result<(), Error> {
+        let patterns = vec![Pattern::new(b"hello".to_vec(), Flag::default(), None)];
+        let db = SharedBlockDatabase::new(patterns)?;
+        let mut scanner = db.create_scanner()?;
+        drop(db);
+
+        let mut matches = Vec::new();
+        scanner.scan(b"hello world", |id, from, to, flags| {
+            matches.push((id, from, to, flags));
+            Scan::Continue
+        })?;
+        assert_eq!(matches.len(), 1);
+
+        Ok(())
+    }
+
+    #[test]
+    fn clone_scanner() -> Result<(), Error> {
+        let patterns = vec![Pattern::new(b"hello".to_vec(), Flag::default(), None)];
+        let db = SharedBlockDatabase::new(patterns)?;
+        let scanner = db.create_scanner()?;
+
+        let mut scanner2 = scanner.clone();
+        drop(scanner);
+
+        let mut matches = Vec::new();
+        scanner2.scan(b"hello", |id, from, to, flags| {
+            matches.push((id, from, to, flags));
+            Scan::Continue
+        })?;
+        assert_eq!(matches.len(), 1);
+
+        Ok(())
+    }
+
+    #[test]
+    fn clone_database() -> Result<(), Error> {
+        let patterns = vec![Pattern::new(b"hello".to_vec(), Flag::default(), None)];
+        let db = SharedBlockDatabase::new(patterns)?;
+        let db2 = db.clone();
+        drop(db);
+
+        let mut scanner = db2.create_scanner()?;
+        let mut matches = Vec::new();
+        scanner.scan(b"hello", |id, from, to, flags| {
+            matches.push((id, from, to, flags));
+            Scan::Continue
+        })?;
+        assert_eq!(matches.len(), 1);
+
+        Ok(())
+    }
+
+    #[test]
+    fn early_termination() -> Result<(), Error> {
+        let patterns = vec![Pattern::new(b"test".to_vec(), Flag::default(), None)];
+        let db = SharedBlockDatabase::new(patterns)?;
+        let mut scanner = db.create_scanner()?;
+
+        let mut match_count = 0;
+        scanner.scan(b"test test test", |_id, _from, _to, _flags| {
+            match_count += 1;
+            if match_count >= 2 {
+                Scan::Terminate
+            } else {
+                Scan::Continue
+            }
+        })?;
+        assert_eq!(match_count, 2);
+
+        Ok(())
+    }
+
+    #[test]
+    fn database_size() -> Result<(), Error> {
+        let patterns = vec![Pattern::new(b"hello".to_vec(), Flag::default(), None)];
+        let db = SharedBlockDatabase::new(patterns)?;
+        assert_eq!(db.size()?, 1000); // N.B. this value may change if the vectorscan code changes
+        Ok(())
+    }
+}


### PR DESCRIPTION
This PR adds a `shared` feature with `SharedBlockDatabase` and `OwnedBlockScanner` — types that decouple scanner lifetime from database lifetime.

This is mostly an ergonomics feature that solves two pain points I'm having with the current `BlockDatabase` / `BlockScanner<'db>` API:
- **Cross-thread sharing**: sharing a compiled database across threads currently requires `Arc<BlockDatabase>`, but the scanners it produces still carry a lifetime parameter tied to the borrow, making them impossible to move to another thread or store independently without `unsafe`.
- **Struct storage**: the borrow on `BlockScanner<'db>` makes it impossible to store a scanner alongside its database in a single struct (self-referential borrow).

Thanks for the great work 🙏🏻 

PS: I'm not too fond of the `shared` naming but thought it might be best to leave that up to you.