### PR TITLE
Add Windows support for vendored Vectorscan and CI improvements

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,7 @@ on:
 
   schedule:
   # Force a run every tuesday at at 0700 UTC
-  - cron: '* 07 * * 2'
+  - cron: '0 07 * * 2'
 
 
 env:
@@ -318,9 +318,7 @@ jobs:
     runs-on: windows-2025
 
     env:
-      CMAKE_GENERATOR: Ninja
       CARGO_TARGET_X86_64_PC_WINDOWS_GNU_LINKER: x86_64-w64-mingw32-gcc
-      CARGO_TARGET_X86_64_PC_WINDOWS_GNU_RUSTFLAGS: -C target-feature=+crt-static -C link-arg=-static
 
     steps:
     - uses: actions/checkout@v6
@@ -329,19 +327,20 @@ jobs:
 
     - uses: msys2/setup-msys2@v2
       with:
-        msystem: UCRT64
+        msystem: MINGW64
         update: true
         path-type: inherit
         install: >-
           git
-          mingw-w64-ucrt-x86_64-toolchain
-          mingw-w64-ucrt-x86_64-cmake
-          mingw-w64-ucrt-x86_64-ninja
-          mingw-w64-ucrt-x86_64-boost
-          mingw-w64-ucrt-x86_64-pkgconf
-          mingw-w64-ucrt-x86_64-pcre2
-          mingw-w64-ucrt-x86_64-python
-          mingw-w64-ucrt-x86_64-zlib
+          make
+          mingw-w64-x86_64-toolchain
+          mingw-w64-x86_64-cmake
+          mingw-w64-x86_64-boost
+          mingw-w64-x86_64-pkgconf
+          mingw-w64-x86_64-ragel
+          mingw-w64-x86_64-pcre2
+          mingw-w64-x86_64-python
+          mingw-w64-x86_64-zlib
 
     - name: Install Rust toolchain
       id: install-rust-toolchain-windows
@@ -349,6 +348,43 @@ jobs:
       with:
         toolchain: stable
         targets: x86_64-pc-windows-gnu
+
+    - name: Build Vectorscan
+      shell: msys2 {0}
+      run: |
+        set -euxo pipefail
+        repo_root="$(pwd)"
+        vectorscan_src="$repo_root/vectorscan-rs-sys/vectorscan"
+        build_dir=/tmp/vectorscan-build
+        rm -rf "$build_dir"
+        mkdir -p "$build_dir"
+        cd "$build_dir"
+        cmake "$vectorscan_src" \
+          -G "MinGW Makefiles" \
+          -DCMAKE_BUILD_TYPE=Release \
+          -DBUILD_SHARED_LIBS=OFF \
+          -DBUILD_STATIC_LIBS=ON \
+          -DBUILD_UNIT=OFF \
+          -DBUILD_TOOLS=OFF \
+          -DFAT_RUNTIME=OFF \
+          -DCMAKE_C_COMPILER=gcc \
+          -DCMAKE_CXX_COMPILER=g++ \
+          -DCMAKE_INSTALL_PREFIX=/mingw64
+        mingw32-make -j"$(nproc)"
+        mingw32-make install
+
+        libgcc_a_path="$(x86_64-w64-mingw32-gcc -print-libgcc-file-name)"
+        libgcc_dir="$(dirname "$libgcc_a_path")"
+        {
+          echo "HYPERSCAN_ROOT=$(cygpath -m /mingw64)"
+          echo "LIBHS_NO_PKG_CONFIG=1"
+          echo "LIBRARY_PATH=/mingw64/lib:${LIBRARY_PATH:-}"
+          echo "CPATH=/mingw64/include:${CPATH:-}"
+          echo "PKG_CONFIG_ALLOW_CROSS=1"
+          echo "PKG_CONFIG_PATH=/mingw64/lib/pkgconfig"
+          echo "PKG_CONFIG_LIBDIR=/mingw64/lib/pkgconfig"
+          echo "CARGO_TARGET_X86_64_PC_WINDOWS_GNU_RUSTFLAGS=-L native=/mingw64/lib -L native=$libgcc_dir -C target-feature=+crt-static -C link-arg=-static"
+        } >> "$GITHUB_ENV"
 
     - name: Build tests
       shell: msys2 {0}
@@ -372,9 +408,7 @@ jobs:
     env:
       CC: clang
       CXX: clang++
-      CMAKE_GENERATOR: Ninja
       CARGO_TARGET_AARCH64_PC_WINDOWS_GNULLVM_LINKER: clang
-      CARGO_TARGET_AARCH64_PC_WINDOWS_GNULLVM_RUSTFLAGS: -C target-feature=+crt-static -C link-arg=-static
 
     steps:
     - uses: actions/checkout@v6
@@ -388,11 +422,12 @@ jobs:
         path-type: inherit
         install: >-
           git
+          make
           mingw-w64-clang-aarch64-toolchain
           mingw-w64-clang-aarch64-cmake
-          mingw-w64-clang-aarch64-ninja
           mingw-w64-clang-aarch64-boost
           mingw-w64-clang-aarch64-pkgconf
+          mingw-w64-clang-aarch64-ragel
           mingw-w64-clang-aarch64-pcre2
           mingw-w64-clang-aarch64-python
           mingw-w64-clang-aarch64-zlib
@@ -403,6 +438,43 @@ jobs:
       with:
         toolchain: stable
         targets: aarch64-pc-windows-gnullvm
+
+    - name: Build Vectorscan
+      shell: msys2 {0}
+      run: |
+        set -euxo pipefail
+        repo_root="$(pwd)"
+        vectorscan_src="$repo_root/vectorscan-rs-sys/vectorscan"
+        build_dir=/tmp/vectorscan-arm64-build
+        rm -rf "$build_dir"
+        mkdir -p "$build_dir"
+        cd "$build_dir"
+        cmake "$vectorscan_src" \
+          -G "MinGW Makefiles" \
+          -DCMAKE_BUILD_TYPE=Release \
+          -DBUILD_SHARED_LIBS=OFF \
+          -DBUILD_STATIC_LIBS=ON \
+          -DBUILD_UNIT=OFF \
+          -DBUILD_TOOLS=OFF \
+          -DFAT_RUNTIME=OFF \
+          -DCMAKE_SYSTEM_NAME=Windows \
+          -DCMAKE_SYSTEM_PROCESSOR=ARM64 \
+          -DCMAKE_C_COMPILER=clang \
+          -DCMAKE_CXX_COMPILER=clang++ \
+          -DCMAKE_INSTALL_PREFIX=/clangarm64
+        mingw32-make -j"$(nproc)"
+        mingw32-make install
+
+        {
+          echo "HYPERSCAN_ROOT=$(cygpath -m /clangarm64)"
+          echo "LIBHS_NO_PKG_CONFIG=1"
+          echo "LIBRARY_PATH=/clangarm64/lib:${LIBRARY_PATH:-}"
+          echo "CPATH=/clangarm64/include:${CPATH:-}"
+          echo "PKG_CONFIG_ALLOW_CROSS=1"
+          echo "PKG_CONFIG_PATH=/clangarm64/lib/pkgconfig"
+          echo "PKG_CONFIG_LIBDIR=/clangarm64/lib/pkgconfig"
+          echo "CARGO_TARGET_AARCH64_PC_WINDOWS_GNULLVM_RUSTFLAGS=-L native=/clangarm64/lib -C target-feature=+crt-static -C link-arg=-static"
+        } >> "$GITHUB_ENV"
 
     - name: Build tests
       shell: msys2 {0}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -377,6 +377,7 @@ jobs:
         libgcc_dir="$(dirname "$libgcc_a_path")"
         {
           echo "HYPERSCAN_ROOT=$(cygpath -m /mingw64)"
+          echo "HYPERSCAN_LINK_KIND=static"
           echo "LIBHS_NO_PKG_CONFIG=1"
           echo "LIBRARY_PATH=/mingw64/lib:${LIBRARY_PATH:-}"
           echo "CPATH=/mingw64/include:${CPATH:-}"
@@ -467,6 +468,7 @@ jobs:
 
         {
           echo "HYPERSCAN_ROOT=$(cygpath -m /clangarm64)"
+          echo "HYPERSCAN_LINK_KIND=static"
           echo "LIBHS_NO_PKG_CONFIG=1"
           echo "LIBRARY_PATH=/clangarm64/lib:${LIBRARY_PATH:-}"
           echo "CPATH=/clangarm64/include:${CPATH:-}"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -266,17 +266,6 @@ jobs:
           check_docs: false
           use_ninja: true
 
-        # Fails:
-        #
-        # - name: windows-2022.x86_64.test
-        #   os: windows-2022
-        #   rust: stable
-        #   profile: test
-        #   features: unit_hyperscan
-        #   install_dependencies: |
-        #   check_docs: false
-        #   use_ninja: false
-
     env:
       CMAKE_GENERATOR: ${{ (matrix.use_ninja && 'Ninja') || 'Unix Makefiles' }}
 
@@ -321,5 +310,56 @@ jobs:
       uses: actions/upload-artifact@v7
       with:
         name: build-timings.${{ matrix.name }}
+        path: target/cargo-timings
+        if-no-files-found: error
+
+  windows-tests:
+    name: CI (windows-2025.x86_64.test)
+    runs-on: windows-2025
+
+    env:
+      CMAKE_GENERATOR: Ninja
+      CARGO_TARGET_X86_64_PC_WINDOWS_GNU_LINKER: x86_64-w64-mingw32-gcc
+
+    steps:
+    - uses: actions/checkout@v6
+      with:
+        persist-credentials: false
+
+    - uses: msys2/setup-msys2@v2
+      with:
+        msystem: UCRT64
+        update: true
+        path-type: inherit
+        install: >-
+          git
+          mingw-w64-ucrt-x86_64-toolchain
+          mingw-w64-ucrt-x86_64-cmake
+          mingw-w64-ucrt-x86_64-ninja
+          mingw-w64-ucrt-x86_64-boost
+          mingw-w64-ucrt-x86_64-pkgconf
+          mingw-w64-ucrt-x86_64-pcre2
+          mingw-w64-ucrt-x86_64-python
+          mingw-w64-ucrt-x86_64-zlib
+
+    - name: Install Rust toolchain
+      id: install-rust-toolchain-windows
+      uses: dtolnay/rust-toolchain@master
+      with:
+        toolchain: stable
+        targets: x86_64-pc-windows-gnu
+
+    - name: Build tests
+      shell: msys2 {0}
+      run: cargo test --no-run -vv --target x86_64-pc-windows-gnu --features unit_hyperscan --timings
+
+    - name: Run tests
+      shell: msys2 {0}
+      run: cargo test -vv --target x86_64-pc-windows-gnu --features unit_hyperscan --timings
+
+    - name: Upload build timings
+      uses: actions/upload-artifact@v7
+      with:
+        name: build-timings.windows-2025.x86_64.test
         path: target/cargo-timings
         if-no-files-found: error

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -313,13 +313,14 @@ jobs:
         path: target/cargo-timings
         if-no-files-found: error
 
-  windows-tests:
+  windows-x64-tests:
     name: CI (windows-2025.x86_64.test)
     runs-on: windows-2025
 
     env:
       CMAKE_GENERATOR: Ninja
       CARGO_TARGET_X86_64_PC_WINDOWS_GNU_LINKER: x86_64-w64-mingw32-gcc
+      CARGO_TARGET_X86_64_PC_WINDOWS_GNU_RUSTFLAGS: -C target-feature=+crt-static -C link-arg=-static
 
     steps:
     - uses: actions/checkout@v6
@@ -351,15 +352,69 @@ jobs:
 
     - name: Build tests
       shell: msys2 {0}
-      run: cargo test --no-run -vv --target x86_64-pc-windows-gnu --features unit_hyperscan --timings
+      run: cargo test --no-run -vv --target x86_64-pc-windows-gnu --timings
 
     - name: Run tests
       shell: msys2 {0}
-      run: cargo test -vv --target x86_64-pc-windows-gnu --features unit_hyperscan --timings
+      run: cargo test -vv --target x86_64-pc-windows-gnu --timings
 
     - name: Upload build timings
       uses: actions/upload-artifact@v7
       with:
         name: build-timings.windows-2025.x86_64.test
+        path: target/cargo-timings
+        if-no-files-found: error
+
+  windows-arm64-tests:
+    name: CI (windows-11.arm64.test)
+    runs-on: windows-11-arm
+
+    env:
+      CC: clang
+      CXX: clang++
+      CMAKE_GENERATOR: Ninja
+      CARGO_TARGET_AARCH64_PC_WINDOWS_GNULLVM_LINKER: clang
+      CARGO_TARGET_AARCH64_PC_WINDOWS_GNULLVM_RUSTFLAGS: -C target-feature=+crt-static -C link-arg=-static
+
+    steps:
+    - uses: actions/checkout@v6
+      with:
+        persist-credentials: false
+
+    - uses: msys2/setup-msys2@v2
+      with:
+        msystem: CLANGARM64
+        update: true
+        path-type: inherit
+        install: >-
+          git
+          mingw-w64-clang-aarch64-toolchain
+          mingw-w64-clang-aarch64-cmake
+          mingw-w64-clang-aarch64-ninja
+          mingw-w64-clang-aarch64-boost
+          mingw-w64-clang-aarch64-pkgconf
+          mingw-w64-clang-aarch64-pcre2
+          mingw-w64-clang-aarch64-python
+          mingw-w64-clang-aarch64-zlib
+
+    - name: Install Rust toolchain
+      id: install-rust-toolchain-windows-arm64
+      uses: dtolnay/rust-toolchain@master
+      with:
+        toolchain: stable
+        targets: aarch64-pc-windows-gnullvm
+
+    - name: Build tests
+      shell: msys2 {0}
+      run: cargo test --no-run -vv --target aarch64-pc-windows-gnullvm --timings
+
+    - name: Run tests
+      shell: msys2 {0}
+      run: cargo test -vv --target aarch64-pc-windows-gnullvm --timings
+
+    - name: Upload build timings
+      uses: actions/upload-artifact@v7
+      with:
+        name: build-timings.windows-11.arm64.test
         path: target/cargo-timings
         if-no-files-found: error

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -323,15 +323,12 @@ jobs:
         - name: windows-2025.x86_64.release
           profile: release
           features: ''
-          use_cpu_native: OFF
         - name: windows-2025.x86_64.test
           profile: test
           features: ''
-          use_cpu_native: OFF
         - name: windows-2025.x86_64.release.cpu_native
           profile: release
           features: cpu_native
-          use_cpu_native: ON
 
     env:
       CARGO_TARGET_X86_64_PC_WINDOWS_GNU_LINKER: x86_64-w64-mingw32-gcc
@@ -365,43 +362,15 @@ jobs:
         toolchain: stable
         targets: x86_64-pc-windows-gnu
 
-    - name: Build Vectorscan
+    - name: Configure vendored Vectorscan build
       shell: msys2 {0}
       run: |
         set -euxo pipefail
-        repo_root="$(pwd)"
-        vectorscan_src="$repo_root/vectorscan-rs-sys/vectorscan"
-        build_dir=/tmp/vectorscan-build
-        rm -rf "$build_dir"
-        mkdir -p "$build_dir"
-        cd "$build_dir"
-        cmake "$vectorscan_src" \
-          -G "MinGW Makefiles" \
-          -DCMAKE_BUILD_TYPE=Release \
-          -DBUILD_SHARED_LIBS=OFF \
-          -DBUILD_STATIC_LIBS=ON \
-          -DBUILD_UNIT=OFF \
-          -DBUILD_TOOLS=OFF \
-          -DFAT_RUNTIME=OFF \
-          -DUSE_CPU_NATIVE=${{ matrix.use_cpu_native }} \
-          -DCMAKE_C_COMPILER=gcc \
-          -DCMAKE_CXX_COMPILER=g++ \
-          -DCMAKE_INSTALL_PREFIX=/mingw64
-        mingw32-make -j"$(nproc)"
-        mingw32-make install
-
         libgcc_a_path="$(x86_64-w64-mingw32-gcc -print-libgcc-file-name)"
         libgcc_dir="$(dirname "$libgcc_a_path")"
         {
-          echo "HYPERSCAN_ROOT=$(cygpath -m /mingw64)"
-          echo "HYPERSCAN_LINK_KIND=static"
           echo "LIBHS_NO_PKG_CONFIG=1"
-          echo "LIBRARY_PATH=/mingw64/lib:${LIBRARY_PATH:-}"
-          echo "CPATH=/mingw64/include:${CPATH:-}"
-          echo "PKG_CONFIG_ALLOW_CROSS=1"
-          echo "PKG_CONFIG_PATH=/mingw64/lib/pkgconfig"
-          echo "PKG_CONFIG_LIBDIR=/mingw64/lib/pkgconfig"
-          echo "CARGO_TARGET_X86_64_PC_WINDOWS_GNU_RUSTFLAGS=-L native=/mingw64/lib -L native=$libgcc_dir -C target-feature=+crt-static -C link-arg=-static"
+          echo "CARGO_TARGET_X86_64_PC_WINDOWS_GNU_RUSTFLAGS=-L native=$libgcc_dir -C target-feature=+crt-static -C link-arg=-static"
         } >> "$GITHUB_ENV"
 
     - name: Build tests
@@ -445,15 +414,12 @@ jobs:
         - name: windows-11.arm64.release
           profile: release
           features: ''
-          use_cpu_native: OFF
         - name: windows-11.arm64.test
           profile: test
           features: ''
-          use_cpu_native: OFF
         - name: windows-11.arm64.release.cpu_native
           profile: release
           features: cpu_native
-          use_cpu_native: ON
 
     env:
       CC: clang
@@ -489,43 +455,13 @@ jobs:
         toolchain: stable
         targets: aarch64-pc-windows-gnullvm
 
-    - name: Build Vectorscan
+    - name: Configure vendored Vectorscan build
       shell: msys2 {0}
       run: |
         set -euxo pipefail
-        repo_root="$(pwd)"
-        vectorscan_src="$repo_root/vectorscan-rs-sys/vectorscan"
-        build_dir=/tmp/vectorscan-arm64-build
-        rm -rf "$build_dir"
-        mkdir -p "$build_dir"
-        cd "$build_dir"
-        cmake "$vectorscan_src" \
-          -G "MinGW Makefiles" \
-          -DCMAKE_BUILD_TYPE=Release \
-          -DBUILD_SHARED_LIBS=OFF \
-          -DBUILD_STATIC_LIBS=ON \
-          -DBUILD_UNIT=OFF \
-          -DBUILD_TOOLS=OFF \
-          -DFAT_RUNTIME=OFF \
-          -DUSE_CPU_NATIVE=${{ matrix.use_cpu_native }} \
-          -DCMAKE_SYSTEM_NAME=Windows \
-          -DCMAKE_SYSTEM_PROCESSOR=ARM64 \
-          -DCMAKE_C_COMPILER=clang \
-          -DCMAKE_CXX_COMPILER=clang++ \
-          -DCMAKE_INSTALL_PREFIX=/clangarm64
-        mingw32-make -j"$(nproc)"
-        mingw32-make install
-
         {
-          echo "HYPERSCAN_ROOT=$(cygpath -m /clangarm64)"
-          echo "HYPERSCAN_LINK_KIND=static"
           echo "LIBHS_NO_PKG_CONFIG=1"
-          echo "LIBRARY_PATH=/clangarm64/lib:${LIBRARY_PATH:-}"
-          echo "CPATH=/clangarm64/include:${CPATH:-}"
-          echo "PKG_CONFIG_ALLOW_CROSS=1"
-          echo "PKG_CONFIG_PATH=/clangarm64/lib/pkgconfig"
-          echo "PKG_CONFIG_LIBDIR=/clangarm64/lib/pkgconfig"
-          echo "CARGO_TARGET_AARCH64_PC_WINDOWS_GNULLVM_RUSTFLAGS=-L native=/clangarm64/lib -C target-feature=+crt-static -C link-arg=-static"
+          echo "CARGO_TARGET_AARCH64_PC_WINDOWS_GNULLVM_RUSTFLAGS=-C target-feature=+crt-static -C link-arg=-static"
         } >> "$GITHUB_ENV"
 
     - name: Build tests

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -314,8 +314,24 @@ jobs:
         if-no-files-found: error
 
   windows-x64-tests:
-    name: CI (windows-2025.x86_64.test)
+    name: CI (${{ matrix.name }})
     runs-on: windows-2025
+
+    strategy:
+      matrix:
+        include:
+        - name: windows-2025.x86_64.release
+          profile: release
+          features: ''
+          use_cpu_native: OFF
+        - name: windows-2025.x86_64.test
+          profile: test
+          features: ''
+          use_cpu_native: OFF
+        - name: windows-2025.x86_64.release.cpu_native
+          profile: release
+          features: cpu_native
+          use_cpu_native: ON
 
     env:
       CARGO_TARGET_X86_64_PC_WINDOWS_GNU_LINKER: x86_64-w64-mingw32-gcc
@@ -367,6 +383,7 @@ jobs:
           -DBUILD_UNIT=OFF \
           -DBUILD_TOOLS=OFF \
           -DFAT_RUNTIME=OFF \
+          -DUSE_CPU_NATIVE=${{ matrix.use_cpu_native }} \
           -DCMAKE_C_COMPILER=gcc \
           -DCMAKE_CXX_COMPILER=g++ \
           -DCMAKE_INSTALL_PREFIX=/mingw64
@@ -389,22 +406,54 @@ jobs:
 
     - name: Build tests
       shell: msys2 {0}
-      run: cargo test --no-run -vv --target x86_64-pc-windows-gnu --timings
+      env:
+        FEATURES: ${{ matrix.features }}
+        PROFILE: ${{ matrix.profile }}
+      run: |
+        features_arg=()
+        if [ -n "$FEATURES" ]; then
+          features_arg=(--features="$FEATURES")
+        fi
+        cargo test --no-run -vv --profile="$PROFILE" --target x86_64-pc-windows-gnu "${features_arg[@]}" --timings
 
     - name: Run tests
       shell: msys2 {0}
-      run: cargo test -vv --target x86_64-pc-windows-gnu --timings
+      env:
+        FEATURES: ${{ matrix.features }}
+        PROFILE: ${{ matrix.profile }}
+      run: |
+        features_arg=()
+        if [ -n "$FEATURES" ]; then
+          features_arg=(--features="$FEATURES")
+        fi
+        cargo test -vv --profile="$PROFILE" --target x86_64-pc-windows-gnu "${features_arg[@]}" --timings
 
     - name: Upload build timings
       uses: actions/upload-artifact@v7
       with:
-        name: build-timings.windows-2025.x86_64.test
+        name: build-timings.${{ matrix.name }}
         path: target/cargo-timings
         if-no-files-found: error
 
   windows-arm64-tests:
-    name: CI (windows-11.arm64.test)
+    name: CI (${{ matrix.name }})
     runs-on: windows-11-arm
+
+    strategy:
+      matrix:
+        include:
+        - name: windows-11.arm64.release
+          profile: release
+          features: ''
+          use_cpu_native: OFF
+        - name: windows-11.arm64.test
+          profile: test
+          features: ''
+          use_cpu_native: OFF
+        - name: windows-11.arm64.release.cpu_native
+          profile: release
+          features: cpu_native
+          use_cpu_native: ON
 
     env:
       CC: clang
@@ -458,6 +507,7 @@ jobs:
           -DBUILD_UNIT=OFF \
           -DBUILD_TOOLS=OFF \
           -DFAT_RUNTIME=OFF \
+          -DUSE_CPU_NATIVE=${{ matrix.use_cpu_native }} \
           -DCMAKE_SYSTEM_NAME=Windows \
           -DCMAKE_SYSTEM_PROCESSOR=ARM64 \
           -DCMAKE_C_COMPILER=clang \
@@ -480,15 +530,31 @@ jobs:
 
     - name: Build tests
       shell: msys2 {0}
-      run: cargo test --no-run -vv --target aarch64-pc-windows-gnullvm --timings
+      env:
+        FEATURES: ${{ matrix.features }}
+        PROFILE: ${{ matrix.profile }}
+      run: |
+        features_arg=()
+        if [ -n "$FEATURES" ]; then
+          features_arg=(--features="$FEATURES")
+        fi
+        cargo test --no-run -vv --profile="$PROFILE" --target aarch64-pc-windows-gnullvm "${features_arg[@]}" --timings
 
     - name: Run tests
       shell: msys2 {0}
-      run: cargo test -vv --target aarch64-pc-windows-gnullvm --timings
+      env:
+        FEATURES: ${{ matrix.features }}
+        PROFILE: ${{ matrix.profile }}
+      run: |
+        features_arg=()
+        if [ -n "$FEATURES" ]; then
+          features_arg=(--features="$FEATURES")
+        fi
+        cargo test -vv --profile="$PROFILE" --target aarch64-pc-windows-gnullvm "${features_arg[@]}" --timings
 
     - name: Upload build timings
       uses: actions/upload-artifact@v7
       with:
-        name: build-timings.windows-11.arm64.test
+        name: build-timings.${{ matrix.name }}
         path: target/cargo-timings
         if-no-files-found: error

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 ### Fixes
 - Fixed a Windows compile error in Vectorscan's FDR code caused by passing `size_t` and `unsigned long` values to `std::min`.
   The comparison now uses matching `size_t` arguments, preserving the existing stride selection behavior while compiling on Windows' 64-bit type model.
+- Fixed a Windows MinGW test-profile link error when building Rust test binaries against the vendored Vectorscan library.
+  The vendored x86 `SuperVector` implementation no longer emits duplicate copy-constructor definitions.
 - Fixed musl cross-compilation by supplying Vectorscan's `unistd.h` and `posix_memalign` configure results for musl targets.
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 ## Unreleased
 
 ### Additions
-- Added Windows build support for the bundled Vectorscan source when targeting MinGW GNU/LLVM toolchains.
+- Added Windows build support for the bundled Vectorscan source when targeting MinGW GNU/LLVM toolchains on x86_64 and aarch64.
 - Added a `HYPERSCAN_ROOT` override so builds can link against an existing Vectorscan/Hyperscan installation instead of compiling the bundled source.
 
 ### Fixes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 
+## Unreleased
+
+### Additions
+- Added Windows build support for the bundled Vectorscan source when targeting MinGW GNU/LLVM toolchains.
+- Added a `HYPERSCAN_ROOT` override so builds can link against an existing Vectorscan/Hyperscan installation instead of compiling the bundled source.
+
+### Fixes
+- Fixed musl cross-compilation by supplying Vectorscan's `unistd.h` and `posix_memalign` configure results for musl targets.
+
+
 ## [v0.0.6](https://github.com/bradlarsen/vectorscan-rs/releases/v0.0.6) (2026-03-12)
 
 ### Changes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ### Additions
 - Added Windows build support for MinGW GNU/LLVM toolchains on x86_64 and aarch64.
-  Because Windows Vectorscan builds are sensitive to the selected CMake generator, compiler, runtime, and target architecture, Windows targets use `HYPERSCAN_ROOT` to link against a Vectorscan/Hyperscan tree built with the matching toolchain.
+  Windows targets build the vendored Vectorscan source by default when `HYPERSCAN_ROOT` is unset.
 - Added a `HYPERSCAN_ROOT` override for linking against an existing Vectorscan/Hyperscan installation.
   The build script prefers static `libhs.a` when available, falls back to dynamic/import libraries, and accepts `HYPERSCAN_LINK_KIND=static` or `HYPERSCAN_LINK_KIND=dynamic` to choose explicitly.
 - Added Windows CI coverage for release, test, and `cpu_native` builds on x86_64 and aarch64.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,10 +8,15 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 ## Unreleased
 
 ### Additions
-- Added Windows build support for the bundled Vectorscan source when targeting MinGW GNU/LLVM toolchains on x86_64 and aarch64.
-- Added a `HYPERSCAN_ROOT` override so builds can link against an existing Vectorscan/Hyperscan installation instead of compiling the bundled source.
+- Added Windows build support for MinGW GNU/LLVM toolchains on x86_64 and aarch64.
+  Because Windows Vectorscan builds are sensitive to the selected CMake generator, compiler, runtime, and target architecture, Windows targets use `HYPERSCAN_ROOT` to link against a Vectorscan/Hyperscan tree built with the matching toolchain.
+- Added a `HYPERSCAN_ROOT` override for linking against an existing Vectorscan/Hyperscan installation.
+  The build script prefers static `libhs.a` when available, falls back to dynamic/import libraries, and accepts `HYPERSCAN_LINK_KIND=static` or `HYPERSCAN_LINK_KIND=dynamic` to choose explicitly.
+- Added Windows CI coverage for release, test, and `cpu_native` builds on x86_64 and aarch64.
 
 ### Fixes
+- Fixed a Windows compile error in Vectorscan's FDR code caused by passing `size_t` and `unsigned long` values to `std::min`.
+  The comparison now uses matching `size_t` arguments, preserving the existing stride selection behavior while compiling on Windows' 64-bit type model.
 - Fixed musl cross-compilation by supplying Vectorscan's `unistd.h` and `posix_memalign` configure results for musl targets.
 
 

--- a/vectorscan-rs-sys/Cargo.toml
+++ b/vectorscan-rs-sys/Cargo.toml
@@ -40,8 +40,6 @@ asan = []
 [build-dependencies]
 bindgen = { version = "0.70", optional = true }
 cmake = "0.1"
-flate2 = "1.0"
-tar = "0.4"
 
 [lib]
 doctest = false

--- a/vectorscan-rs-sys/README.md
+++ b/vectorscan-rs-sys/README.md
@@ -11,10 +11,12 @@ This crate builds a vendored copy of Vectorscan from source.
 - [CMake](https://cmake.org)
 - Optional: [Clang](https://clang.llvm.org), when building with the `bindgen` feature
 
-This has been tested on x86_64 Linux, x86_64 macOS, aarch64 macOS, and x86_64 Windows with MSYS2 UCRT64.
+This has been tested on x86_64 Linux, x86_64 macOS, and aarch64 macOS.
+The CI matrix also exercises x86_64 Windows with MSYS2 UCRT64 and aarch64 Windows with MSYS2 CLANGARM64.
 
-On Windows GNU targets, install the matching MSYS2 MinGW toolchain, CMake, Boost, Ninja, pkgconf, PCRE2, zlib, and Python packages before building.
+On Windows GNU/LLVM targets, install the matching MSYS2 MinGW toolchain, CMake, Boost, Ninja, pkgconf, PCRE2, zlib, and Python packages before building.
 For example, the `x86_64-pc-windows-gnu` target can be built from an MSYS2 UCRT64 shell with the `mingw-w64-ucrt-x86_64-*` packages for those dependencies.
+The `aarch64-pc-windows-gnullvm` target can be built from an MSYS2 CLANGARM64 shell with the `mingw-w64-clang-aarch64-*` packages.
 
 Set `HYPERSCAN_ROOT` to the install prefix of an existing Vectorscan/Hyperscan installation to link against that installation instead of building the bundled source.
 The build script expects headers under `$HYPERSCAN_ROOT/include` and libraries under `$HYPERSCAN_ROOT/lib` or `$HYPERSCAN_ROOT/lib64`.

--- a/vectorscan-rs-sys/README.md
+++ b/vectorscan-rs-sys/README.md
@@ -18,9 +18,6 @@ Set `HYPERSCAN_ROOT` to the install prefix of an existing Vectorscan/Hyperscan i
 The build script expects headers under `$HYPERSCAN_ROOT/include` and libraries under `$HYPERSCAN_ROOT/lib` or `$HYPERSCAN_ROOT/lib64`.
 When `HYPERSCAN_ROOT` is set, the build script prefers static linkage if `libhs.a` is present, otherwise it uses a dynamic/import library if one is present.
 Set `HYPERSCAN_LINK_KIND=static` or `HYPERSCAN_LINK_KIND=dynamic` to choose explicitly.
-On Windows GNU/LLVM targets, `HYPERSCAN_ROOT` is required.
-Build and install Vectorscan with the matching MSYS2 MinGW toolchain first, then point `HYPERSCAN_ROOT` at that install prefix.
-For example, use the MSYS2 MINGW64 toolchain and `/mingw64` prefix for `x86_64-pc-windows-gnu`, or the MSYS2 CLANGARM64 toolchain and `/clangarm64` prefix for `aarch64-pc-windows-gnullvm`.
 
 
 ## Implementation Notes

--- a/vectorscan-rs-sys/README.md
+++ b/vectorscan-rs-sys/README.md
@@ -11,7 +11,13 @@ This crate builds a vendored copy of Vectorscan from source.
 - [CMake](https://cmake.org)
 - Optional: [Clang](https://clang.llvm.org), when building with the `bindgen` feature
 
-This has been tested on x86_64 Linux, x86_64 macOS, and aarch64 macOS.
+This has been tested on x86_64 Linux, x86_64 macOS, aarch64 macOS, and x86_64 Windows with MSYS2 UCRT64.
+
+On Windows GNU targets, install the matching MSYS2 MinGW toolchain, CMake, Boost, Ninja, pkgconf, PCRE2, zlib, and Python packages before building.
+For example, the `x86_64-pc-windows-gnu` target can be built from an MSYS2 UCRT64 shell with the `mingw-w64-ucrt-x86_64-*` packages for those dependencies.
+
+Set `HYPERSCAN_ROOT` to the install prefix of an existing Vectorscan/Hyperscan installation to link against that installation instead of building the bundled source.
+The build script expects headers under `$HYPERSCAN_ROOT/include` and libraries under `$HYPERSCAN_ROOT/lib` or `$HYPERSCAN_ROOT/lib64`.
 
 
 ## Implementation Notes

--- a/vectorscan-rs-sys/README.md
+++ b/vectorscan-rs-sys/README.md
@@ -12,14 +12,13 @@ This crate builds a vendored copy of Vectorscan from source.
 - Optional: [Clang](https://clang.llvm.org), when building with the `bindgen` feature
 
 This has been tested on x86_64 Linux, x86_64 macOS, and aarch64 macOS.
-The CI matrix also exercises x86_64 Windows with MSYS2 UCRT64 and aarch64 Windows with MSYS2 CLANGARM64.
-
-On Windows GNU/LLVM targets, install the matching MSYS2 MinGW toolchain, CMake, Boost, Ninja, pkgconf, PCRE2, zlib, and Python packages before building.
-For example, the `x86_64-pc-windows-gnu` target can be built from an MSYS2 UCRT64 shell with the `mingw-w64-ucrt-x86_64-*` packages for those dependencies.
-The `aarch64-pc-windows-gnullvm` target can be built from an MSYS2 CLANGARM64 shell with the `mingw-w64-clang-aarch64-*` packages.
+The CI matrix also exercises x86_64 Windows with MSYS2 MINGW64 and aarch64 Windows with MSYS2 CLANGARM64.
 
 Set `HYPERSCAN_ROOT` to the install prefix of an existing Vectorscan/Hyperscan installation to link against that installation instead of building the bundled source.
 The build script expects headers under `$HYPERSCAN_ROOT/include` and libraries under `$HYPERSCAN_ROOT/lib` or `$HYPERSCAN_ROOT/lib64`.
+On Windows GNU/LLVM targets, `HYPERSCAN_ROOT` is required.
+Build and install Vectorscan with the matching MSYS2 MinGW toolchain first, then point `HYPERSCAN_ROOT` at that install prefix.
+For example, use the MSYS2 MINGW64 toolchain and `/mingw64` prefix for `x86_64-pc-windows-gnu`, or the MSYS2 CLANGARM64 toolchain and `/clangarm64` prefix for `aarch64-pc-windows-gnullvm`.
 
 
 ## Implementation Notes

--- a/vectorscan-rs-sys/README.md
+++ b/vectorscan-rs-sys/README.md
@@ -16,6 +16,8 @@ The CI matrix also exercises x86_64 Windows with MSYS2 MINGW64 and aarch64 Windo
 
 Set `HYPERSCAN_ROOT` to the install prefix of an existing Vectorscan/Hyperscan installation to link against that installation instead of building the bundled source.
 The build script expects headers under `$HYPERSCAN_ROOT/include` and libraries under `$HYPERSCAN_ROOT/lib` or `$HYPERSCAN_ROOT/lib64`.
+When `HYPERSCAN_ROOT` is set, the build script prefers static linkage if `libhs.a` is present, otherwise it uses a dynamic/import library if one is present.
+Set `HYPERSCAN_LINK_KIND=static` or `HYPERSCAN_LINK_KIND=dynamic` to choose explicitly.
 On Windows GNU/LLVM targets, `HYPERSCAN_ROOT` is required.
 Build and install Vectorscan with the matching MSYS2 MinGW toolchain first, then point `HYPERSCAN_ROOT` at that install prefix.
 For example, use the MSYS2 MINGW64 toolchain and `/mingw64` prefix for `x86_64-pc-windows-gnu`, or the MSYS2 CLANGARM64 toolchain and `/clangarm64` prefix for `aarch64-pc-windows-gnullvm`.

--- a/vectorscan-rs-sys/build.rs
+++ b/vectorscan-rs-sys/build.rs
@@ -1,3 +1,4 @@
+use std::collections::BTreeSet;
 use std::path::{Path, PathBuf};
 use std::process::Command;
 
@@ -42,6 +43,9 @@ fn main() {
     // rerun: see https://doc.rust-lang.org/cargo/reference/build-scripts.html#change-detection
     println!("cargo:rerun-if-changed=build.rs");
     println!("cargo:rerun-if-env-changed=HYPERSCAN_ROOT");
+    println!("cargo:rerun-if-env-changed=MINGW_PREFIX");
+    println!("cargo:rerun-if-env-changed=MSYSTEM_PREFIX");
+    println!("cargo:rerun-if-env-changed=PATH");
 
     let manifest_dir = PathBuf::from(env("CARGO_MANIFEST_DIR"));
     let out_dir = PathBuf::from(env("OUT_DIR"));
@@ -211,12 +215,22 @@ fn link_cpp_runtime(target: &Target) {
         } else if target.is_windows_gnullvm() {
             // On clang/LLVM MinGW targets, prefer static LLVM runtime linkage to avoid runtime
             // DLL dependencies.
+            add_windows_runtime_search_dirs(
+                target,
+                &["libc++.a", "libc++abi.a", "libunwind.a"],
+                &windows_clang_tools(target),
+            );
             println!("cargo:rustc-link-lib=static=c++");
             println!("cargo:rustc-link-lib=static=c++abi");
             println!("cargo:rustc-link-lib=static=unwind");
         } else if target.env == "gnu" {
             // On MinGW GNU targets, prefer static GNU C++ runtime linkage to avoid runtime DLL
             // dependencies.
+            add_windows_runtime_search_dirs(
+                target,
+                &["libstdc++.a", "libgcc.a", "libwinpthread.a"],
+                &windows_gnu_tools(target),
+            );
             println!("cargo:rustc-link-lib=static=stdc++");
             println!("cargo:rustc-link-lib=static=gcc");
             println!("cargo:rustc-link-lib=static=winpthread");
@@ -247,6 +261,125 @@ fn link_cpp_runtime(target: &Target) {
     } else {
         panic!("No compatible compiler found: either clang or gcc is needed");
     }
+}
+
+fn windows_gnu_tools(target: &Target) -> Vec<&'static str> {
+    match target.arch.as_str() {
+        "x86_64" => vec![
+            "x86_64-w64-mingw32-g++",
+            "x86_64-w64-mingw32-gcc",
+            "g++",
+            "gcc",
+            "c++",
+        ],
+        "aarch64" => vec![
+            "aarch64-w64-mingw32-g++",
+            "aarch64-w64-mingw32-gcc",
+            "g++",
+            "gcc",
+            "c++",
+        ],
+        _ => vec!["g++", "gcc", "c++"],
+    }
+}
+
+fn windows_clang_tools(target: &Target) -> Vec<&'static str> {
+    match target.arch.as_str() {
+        "x86_64" => vec![
+            "x86_64-w64-mingw32-clang++",
+            "x86_64-w64-mingw32-clang",
+            "clang++",
+            "clang",
+        ],
+        "aarch64" => vec![
+            "aarch64-w64-mingw32-clang++",
+            "aarch64-w64-mingw32-clang",
+            "clang++",
+            "clang",
+        ],
+        _ => vec!["clang++", "clang"],
+    }
+}
+
+fn add_windows_runtime_search_dirs(target: &Target, lib_names: &[&str], tools: &[&str]) {
+    if !target.is_windows() {
+        return;
+    }
+
+    let mut dirs = BTreeSet::new();
+
+    for tool in tools {
+        for lib_name in lib_names {
+            if let Some(dir) = runtime_lib_dir_from_tool(tool, lib_name) {
+                dirs.insert(dir);
+            }
+        }
+    }
+
+    for prefix_var in ["MINGW_PREFIX", "MSYSTEM_PREFIX"] {
+        if let Some(prefix) = std::env::var_os(prefix_var) {
+            let lib_dir = PathBuf::from(prefix).join("lib");
+            if lib_names.iter().any(|lib_name| {
+                resolve_existing_path(lib_dir.join(lib_name))
+                    .map(|lib_path| lib_path.is_file())
+                    .unwrap_or(false)
+            }) {
+                if let Some(dir) = resolve_existing_path(lib_dir) {
+                    dirs.insert(dir);
+                }
+            }
+        }
+    }
+
+    for dir in dirs {
+        println!("cargo:rustc-link-search=native={}", dir.display());
+    }
+}
+
+fn runtime_lib_dir_from_tool(tool: &str, lib_name: &str) -> Option<PathBuf> {
+    let output = Command::new(tool)
+        .arg(format!("-print-file-name={lib_name}"))
+        .output()
+        .ok()?;
+    if !output.status.success() {
+        return None;
+    }
+
+    let stdout = String::from_utf8(output.stdout).ok()?;
+    let lib_path = PathBuf::from(stdout.trim());
+    if lib_path.as_os_str().is_empty() || lib_path == PathBuf::from(lib_name) {
+        return None;
+    }
+
+    let lib_path = resolve_existing_path(lib_path)?;
+    if !lib_path.is_file() {
+        return None;
+    }
+
+    lib_path.parent().map(Path::to_path_buf)
+}
+
+fn resolve_existing_path(path: PathBuf) -> Option<PathBuf> {
+    if path.exists() {
+        return Some(path);
+    }
+
+    let path_str = path.to_string_lossy();
+    if !path_str.starts_with('/') {
+        return None;
+    }
+
+    let output = Command::new("cygpath")
+        .args(["-m", path_str.as_ref()])
+        .output()
+        .ok()?;
+    if !output.status.success() {
+        return None;
+    }
+
+    let stdout = String::from_utf8(output.stdout).ok()?;
+    let converted = PathBuf::from(stdout.trim());
+    converted.exists().then_some(converted)
 }
 
 fn write_bindings(manifest_dir: &Path, out_dir: &Path, include_dir: &Path) {

--- a/vectorscan-rs-sys/build.rs
+++ b/vectorscan-rs-sys/build.rs
@@ -57,6 +57,11 @@ fn main() {
             lib_dirs: lib_dirs_for_root(Path::new(&hs_root)),
             source_built: false,
         },
+        None if target.is_windows() => {
+            panic!(
+                "HYPERSCAN_ROOT must point to an installed Vectorscan/Hyperscan prefix on Windows"
+            )
+        }
         None => build_vendored_vectorscan(&manifest_dir, &out_dir, &target),
     };
 

--- a/vectorscan-rs-sys/build.rs
+++ b/vectorscan-rs-sys/build.rs
@@ -1,4 +1,4 @@
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use std::process::Command;
 
 /// Get the environment variable with the given name, panicking if it is not set.
@@ -6,172 +6,259 @@ fn env(name: &str) -> String {
     std::env::var(name).unwrap_or_else(|_| panic!("`{}` should be set in the environment", name))
 }
 
+#[derive(Debug)]
+struct Target {
+    triple: String,
+    os: String,
+    env: String,
+    arch: String,
+}
+
+impl Target {
+    fn from_env() -> Self {
+        Self {
+            triple: env("TARGET"),
+            os: env("CARGO_CFG_TARGET_OS"),
+            env: std::env::var("CARGO_CFG_TARGET_ENV").unwrap_or_default(),
+            arch: env("CARGO_CFG_TARGET_ARCH"),
+        }
+    }
+
+    fn is_windows(&self) -> bool {
+        self.os == "windows"
+    }
+
+    fn is_musl(&self) -> bool {
+        self.triple.ends_with("-musl")
+    }
+
+    fn is_windows_gnullvm(&self) -> bool {
+        self.triple.ends_with("gnullvm")
+    }
+}
+
 fn main() {
     // Note: use `rerun-if-changed=build.rs` to indicate that this build script *shouldn't* be
     // rerun: see https://doc.rust-lang.org/cargo/reference/build-scripts.html#change-detection
     println!("cargo:rerun-if-changed=build.rs");
+    println!("cargo:rerun-if-env-changed=HYPERSCAN_ROOT");
 
     let manifest_dir = PathBuf::from(env("CARGO_MANIFEST_DIR"));
     let out_dir = PathBuf::from(env("OUT_DIR"));
+    let target = Target::from_env();
 
-    let include_dir = out_dir
-        .join("include")
-        .into_os_string()
-        .into_string()
-        .unwrap();
+    let build = match std::env::var_os("HYPERSCAN_ROOT") {
+        Some(hs_root) => BuildOutput {
+            include_dir: PathBuf::from(&hs_root).join("include"),
+            lib_dirs: lib_dirs_for_root(Path::new(&hs_root)),
+            source_built: false,
+        },
+        None => build_vendored_vectorscan(&manifest_dir, &out_dir, &target),
+    };
 
-    // Choose appropriate C++ runtime library
-    {
-        let compiler_version_out = String::from_utf8(
-            Command::new("c++")
-                .args(["-v"])
-                .output()
-                .expect("Failed to get C++ compiler version")
-                .stderr,
-        )
-        .unwrap();
+    link_library_dirs(&build.lib_dirs);
+    println!("cargo:rustc-link-lib=static=hs");
+    link_cpp_runtime(&target);
 
-        if compiler_version_out.contains("gcc") {
-            println!("cargo:rustc-link-lib=stdc++");
-        } else if compiler_version_out.contains("clang") {
-            println!("cargo:rustc-link-lib=c++");
-        } else {
-            panic!("No compatible compiler found: either clang or gcc is needed");
-        }
-    }
+    run_hyperscan_unit_tests(&out_dir, &target, build.source_built);
+    write_bindings(&manifest_dir, &out_dir, &build.include_dir);
+}
 
+struct BuildOutput {
+    include_dir: PathBuf,
+    lib_dirs: Vec<PathBuf>,
+    source_built: bool,
+}
+
+fn build_vendored_vectorscan(manifest_dir: &Path, out_dir: &Path, target: &Target) -> BuildOutput {
+    let include_dir = out_dir.join("include");
     let vectorscan_src_dir = manifest_dir.join("vectorscan");
+    let mut cfg = cmake::Config::new(&vectorscan_src_dir);
 
-    // Build with cmake
-    {
-        let mut cfg = cmake::Config::new(&vectorscan_src_dir);
-
-        macro_rules! cfg_define_feature {
-            ($cmake_feature: tt, $cargo_feature: tt) => {
-                cfg.define(
-                    $cmake_feature,
-                    if cfg!(feature = $cargo_feature) {
-                        "ON"
-                    } else {
-                        "OFF"
-                    },
-                )
-            };
-        }
-
-        let profile = {
-            // See https://doc.rust-lang.org/cargo/reference/profiles.html#opt-level for possible values
-            match env("OPT_LEVEL").as_str() {
-                "0" => "Debug",
-                "s" | "z" => "MinSizeRel",
-                _ => "Release",
-            }
+    macro_rules! cfg_define_feature {
+        ($cmake_feature: tt, $cargo_feature: tt) => {
+            cfg.define(
+                $cmake_feature,
+                if cfg!(feature = $cargo_feature) {
+                    "ON"
+                } else {
+                    "OFF"
+                },
+            )
         };
+    }
 
-        cfg.profile(profile)
-            .define("CMAKE_INSTALL_INCLUDEDIR", &include_dir)
-            .define("CMAKE_VERBOSE_MAKEFILE", "ON")
-            .define("BUILD_SHARED_LIBS", "OFF")
-            .define("BUILD_STATIC_LIBS", "ON")
-            .define("FAT_RUNTIME", "OFF")
-            .define("WARNINGS_AS_ERRORS", "OFF")
-            .define("BUILD_EXAMPLES", "OFF")
-            .define("BUILD_BENCHMARKS", "OFF")
-            .define("BUILD_DOC", "OFF")
-            .define("BUILD_TOOLS", "OFF");
+    let profile = {
+        // See https://doc.rust-lang.org/cargo/reference/profiles.html#opt-level for possible values
+        match env("OPT_LEVEL").as_str() {
+            "0" => "Debug",
+            "s" | "z" => "MinSizeRel",
+            _ => "Release",
+        }
+    };
 
-        cfg_define_feature!("BUILD_UNIT", "unit_hyperscan");
-        cfg_define_feature!("USE_CPU_NATIVE", "cpu_native");
+    cfg.profile(profile)
+        .define("CMAKE_INSTALL_INCLUDEDIR", &include_dir)
+        .define("CMAKE_VERBOSE_MAKEFILE", "ON")
+        .define("BUILD_SHARED_LIBS", "OFF")
+        .define("BUILD_STATIC_LIBS", "ON")
+        .define("FAT_RUNTIME", "OFF")
+        .define("WARNINGS_AS_ERRORS", "OFF")
+        .define("BUILD_EXAMPLES", "OFF")
+        .define("BUILD_BENCHMARKS", "OFF")
+        .define("BUILD_DOC", "OFF")
+        .define("BUILD_TOOLS", "OFF");
 
-        if cfg!(feature = "asan") {
-            cfg.define("SANITIZE", "address");
+    cfg_define_feature!("BUILD_UNIT", "unit_hyperscan");
+    cfg_define_feature!("USE_CPU_NATIVE", "cpu_native");
+
+    if cfg!(feature = "asan") {
+        cfg.define("SANITIZE", "address");
+    }
+
+    // NOTE: Several Vectorscan feature flags can be set based on available CPU SIMD features.
+    // Enabling these according to availability on the build system CPU is fragile, however:
+    // the resulting binary will not work correctly on machines with CPUs with different SIMD
+    // support.
+    //
+    // By default, we simply disable these options. However, using the `simd-specialization`
+    // feature flag, these Vectorscan features will be enabled if the build system's CPU
+    // supports them.
+    //
+    // See
+    // https://doc.rust-lang.org/reference/attributes/codegen.html#the-target_feature-attribute
+    // for supported target_feature values.
+    if cfg!(feature = "simd_specialization") {
+        macro_rules! x86_64_feature {
+            ($feature: tt) => {{
+                #[cfg(target_arch = "x86_64")]
+                if std::arch::is_x86_feature_detected!($feature) {
+                    "ON"
+                } else {
+                    "OFF"
+                }
+                #[cfg(not(target_arch = "x86_64"))]
+                "OFF"
+            }};
         }
 
-        // NOTE: Several Vectorscan feature flags can be set based on available CPU SIMD features.
-        // Enabling these according to availability on the build system CPU is fragile, however:
-        // the resulting binary will not work correctly on machines with CPUs with different SIMD
-        // support.
-        //
-        // By default, we simply disable these options. However, using the `simd-specialization`
-        // feature flag, these Vectorscan features will be enabled if the build system's CPU
-        // supports them.
-        //
-        // See
-        // https://doc.rust-lang.org/reference/attributes/codegen.html#the-target_feature-attribute
-        // for supported target_feature values.
-
-        if cfg!(feature = "simd_specialization") {
-            macro_rules! x86_64_feature {
-                ($feature: tt) => {{
-                    #[cfg(target_arch = "x86_64")]
-                    if std::arch::is_x86_feature_detected!($feature) {
-                        "ON"
-                    } else {
-                        "OFF"
-                    }
-                    #[cfg(not(target_arch = "x86_64"))]
+        macro_rules! aarch64_feature {
+            ($feature: tt) => {{
+                #[cfg(target_arch = "aarch64")]
+                if std::arch::is_aarch64_feature_detected!($feature) {
+                    "ON"
+                } else {
                     "OFF"
-                }};
-            }
+                }
+                #[cfg(not(target_arch = "aarch64"))]
+                "OFF"
+            }};
+        }
 
-            macro_rules! aarch64_feature {
-                ($feature: tt) => {{
-                    #[cfg(target_arch = "aarch64")]
-                    if std::arch::is_aarch64_feature_detected!($feature) {
-                        "ON"
-                    } else {
-                        "OFF"
-                    }
-                    #[cfg(not(target_arch = "aarch64"))]
-                    "OFF"
-                }};
-            }
+        cfg.define("BUILD_AVX2", x86_64_feature!("avx2"));
+        // XXX use avx512vbmi as a proxy for this, as it's not clear which particular avx512
+        // instructions are needed
+        cfg.define("BUILD_AVX512", x86_64_feature!("avx512vbmi"));
+        cfg.define("BUILD_AVX512VBMI", x86_64_feature!("avx512vbmi"));
 
-            cfg.define("BUILD_AVX2", x86_64_feature!("avx2"));
-            // XXX use avx512vbmi as a proxy for this, as it's not clear which particular avx512
-            // instructions are needed
-            cfg.define("BUILD_AVX512", x86_64_feature!("avx512vbmi"));
-            cfg.define("BUILD_AVX512VBMI", x86_64_feature!("avx512vbmi"));
+        cfg.define("BUILD_SVE", aarch64_feature!("sve"));
+        cfg.define("BUILD_SVE2", aarch64_feature!("sve2"));
+        cfg.define("BUILD_SVE2_BITPERM", aarch64_feature!("sve2-bitperm"));
+    } else {
+        cfg.define("BUILD_AVX2", "OFF")
+            .define("BUILD_AVX512", "OFF")
+            .define("BUILD_AVX512VBMI", "OFF")
+            .define("BUILD_SVE", "OFF")
+            .define("BUILD_SVE2", "OFF")
+            .define("BUILD_SVE2_BITPERM", "OFF");
+    }
 
-            cfg.define("BUILD_SVE", aarch64_feature!("sve"));
-            cfg.define("BUILD_SVE2", aarch64_feature!("sve2"));
-            cfg.define("BUILD_SVE2_BITPERM", aarch64_feature!("sve2-bitperm"));
+    // Under cargo-zigbuild for musl targets, Vectorscan's configure-time probes can incorrectly
+    // miss posix_memalign/unistd. Scope this workaround to musl targets only.
+    if target.is_musl() {
+        cfg.define("HAVE_UNISTD_H", "1")
+            .define("HAVE_POSIX_MEMALIGN", "1");
+    }
+
+    if target.is_windows() && target.arch == "aarch64" {
+        cfg.define("CMAKE_SYSTEM_NAME", "Windows")
+            .define("CMAKE_SYSTEM_PROCESSOR", "ARM64");
+    }
+
+    let dst = cfg.build();
+
+    BuildOutput {
+        include_dir,
+        lib_dirs: vec![dst.join("lib"), dst.join("lib64")],
+        source_built: true,
+    }
+}
+
+fn lib_dirs_for_root(root: &Path) -> Vec<PathBuf> {
+    vec![root.join("lib"), root.join("lib64")]
+}
+
+fn link_library_dirs(lib_dirs: &[PathBuf]) {
+    for lib_dir in lib_dirs {
+        println!("cargo:rustc-link-search=native={}", lib_dir.display());
+    }
+}
+
+fn link_cpp_runtime(target: &Target) {
+    if target.is_windows() {
+        if target.env == "msvc" {
+            // MSVC selects its own C++ runtime through the selected Rust/C toolchain.
+        } else if target.is_windows_gnullvm() {
+            // On clang/LLVM MinGW targets, prefer static LLVM runtime linkage to avoid runtime
+            // DLL dependencies.
+            println!("cargo:rustc-link-lib=static=c++");
+            println!("cargo:rustc-link-lib=static=c++abi");
+            println!("cargo:rustc-link-lib=static=unwind");
+        } else if target.env == "gnu" {
+            // On MinGW GNU targets, prefer static GNU C++ runtime linkage to avoid runtime DLL
+            // dependencies.
+            println!("cargo:rustc-link-lib=static=stdc++");
+            println!("cargo:rustc-link-lib=static=gcc");
+            println!("cargo:rustc-link-lib=static=winpthread");
         } else {
-            cfg.define("BUILD_AVX2", "OFF")
-                .define("BUILD_AVX512", "OFF")
-                .define("BUILD_AVX512VBMI", "OFF")
-                .define("BUILD_SVE", "OFF")
-                .define("BUILD_SVE2", "OFF")
-                .define("BUILD_SVE2_BITPERM", "OFF");
+            println!("cargo:rustc-link-lib=stdc++");
         }
-
-        let dst = cfg.build();
-
-        println!("cargo:rustc-link-lib=static=hs");
-        println!("cargo:rustc-link-search={}", dst.join("lib").display());
-        println!("cargo:rustc-link-search={}", dst.join("lib64").display());
+        return;
     }
 
-    // Run hyperscan unit test suite
-    #[cfg(feature = "unit_hyperscan")]
-    {
-        let unittests = out_dir.join("build").join("bin").join("unit-hyperscan");
-        match Command::new(unittests).status() {
-            Ok(rc) if rc.success() => {}
-            Ok(rc) => panic!("Failed to run unit tests: exit with code {rc}"),
-            Err(e) => panic!("Failed to run unit tests: {e}"),
-        }
+    if target.os == "macos" {
+        println!("cargo:rustc-link-lib=c++");
+        return;
     }
 
-    // Run bindgen if needed, or else use the pre-generated bindings
+    let compiler_version_out = String::from_utf8(
+        Command::new("c++")
+            .args(["-v"])
+            .output()
+            .expect("Failed to get C++ compiler version")
+            .stderr,
+    )
+    .unwrap();
+
+    if compiler_version_out.contains("gcc") {
+        println!("cargo:rustc-link-lib=stdc++");
+    } else if compiler_version_out.contains("clang") {
+        println!("cargo:rustc-link-lib=c++");
+    } else {
+        panic!("No compatible compiler found: either clang or gcc is needed");
+    }
+}
+
+fn write_bindings(manifest_dir: &Path, out_dir: &Path, include_dir: &Path) {
     #[cfg(feature = "bindgen")]
     {
+        let _ = manifest_dir;
         let config = bindgen::Builder::default()
             .allowlist_function("hs_.*")
             .allowlist_type("hs_.*")
             .allowlist_var("HS_.*")
             .header("wrapper.h")
-            .clang_arg(format!("-I{}", &include_dir));
+            .clang_arg(format!("-I{}", include_dir.display()));
         config
             .generate()
             .expect("Unable to generate bindings")
@@ -180,7 +267,37 @@ fn main() {
     }
     #[cfg(not(feature = "bindgen"))]
     {
-        std::fs::copy("src/bindings.rs", out_dir.join("bindings.rs"))
-            .expect("Failed to write Rust bindings to Vectorscan");
+        let _ = include_dir;
+        std::fs::copy(
+            manifest_dir.join("src").join("bindings.rs"),
+            out_dir.join("bindings.rs"),
+        )
+        .expect("Failed to write Rust bindings to Vectorscan");
+    }
+}
+
+fn run_hyperscan_unit_tests(out_dir: &Path, target: &Target, source_built: bool) {
+    #[cfg(feature = "unit_hyperscan")]
+    {
+        if !source_built {
+            panic!("The unit_hyperscan feature requires building the vendored Vectorscan source");
+        }
+
+        let executable_name = if target.is_windows() {
+            "unit-hyperscan.exe"
+        } else {
+            "unit-hyperscan"
+        };
+        let unittests = out_dir.join("build").join("bin").join(executable_name);
+        match Command::new(unittests).status() {
+            Ok(rc) if rc.success() => {}
+            Ok(rc) => panic!("Failed to run unit tests: exit with code {rc}"),
+            Err(e) => panic!("Failed to run unit tests: {e}"),
+        }
+    }
+
+    #[cfg(not(feature = "unit_hyperscan"))]
+    {
+        let _ = (out_dir, target, source_built);
     }
 }

--- a/vectorscan-rs-sys/build.rs
+++ b/vectorscan-rs-sys/build.rs
@@ -43,6 +43,7 @@ fn main() {
     // rerun: see https://doc.rust-lang.org/cargo/reference/build-scripts.html#change-detection
     println!("cargo:rerun-if-changed=build.rs");
     println!("cargo:rerun-if-env-changed=HYPERSCAN_ROOT");
+    println!("cargo:rerun-if-env-changed=HYPERSCAN_LINK_KIND");
     println!("cargo:rerun-if-env-changed=MINGW_PREFIX");
     println!("cargo:rerun-if-env-changed=MSYSTEM_PREFIX");
     println!("cargo:rerun-if-env-changed=PATH");
@@ -52,11 +53,7 @@ fn main() {
     let target = Target::from_env();
 
     let build = match std::env::var_os("HYPERSCAN_ROOT") {
-        Some(hs_root) => BuildOutput {
-            include_dir: PathBuf::from(&hs_root).join("include"),
-            lib_dirs: lib_dirs_for_root(Path::new(&hs_root)),
-            source_built: false,
-        },
+        Some(hs_root) => build_existing_hyperscan(Path::new(&hs_root)),
         None if target.is_windows() => {
             panic!(
                 "HYPERSCAN_ROOT must point to an installed Vectorscan/Hyperscan prefix on Windows"
@@ -66,7 +63,7 @@ fn main() {
     };
 
     link_library_dirs(&build.lib_dirs);
-    println!("cargo:rustc-link-lib=static=hs");
+    link_hyperscan(build.link_kind);
     link_cpp_runtime(&target);
 
     run_hyperscan_unit_tests(&out_dir, &target, build.source_built);
@@ -77,6 +74,25 @@ struct BuildOutput {
     include_dir: PathBuf,
     lib_dirs: Vec<PathBuf>,
     source_built: bool,
+    link_kind: LinkKind,
+}
+
+#[derive(Clone, Copy)]
+enum LinkKind {
+    Static,
+    Dynamic,
+}
+
+impl LinkKind {
+    fn from_env() -> Option<Self> {
+        match std::env::var("HYPERSCAN_LINK_KIND").ok()?.as_str() {
+            "static" => Some(Self::Static),
+            "dynamic" | "dylib" => Some(Self::Dynamic),
+            other => panic!(
+                "Unsupported HYPERSCAN_LINK_KIND={other}; expected `static`, `dynamic`, or `dylib`"
+            ),
+        }
+    }
 }
 
 fn build_vendored_vectorscan(manifest_dir: &Path, out_dir: &Path, target: &Target) -> BuildOutput {
@@ -200,6 +216,17 @@ fn build_vendored_vectorscan(manifest_dir: &Path, out_dir: &Path, target: &Targe
         include_dir,
         lib_dirs: vec![dst.join("lib"), dst.join("lib64")],
         source_built: true,
+        link_kind: LinkKind::Static,
+    }
+}
+
+fn build_existing_hyperscan(root: &Path) -> BuildOutput {
+    let lib_dirs = lib_dirs_for_root(root);
+    BuildOutput {
+        include_dir: root.join("include"),
+        link_kind: LinkKind::from_env().unwrap_or_else(|| detect_hyperscan_link_kind(&lib_dirs)),
+        lib_dirs,
+        source_built: false,
     }
 }
 
@@ -211,6 +238,40 @@ fn link_library_dirs(lib_dirs: &[PathBuf]) {
     for lib_dir in lib_dirs {
         println!("cargo:rustc-link-search=native={}", lib_dir.display());
     }
+}
+
+fn link_hyperscan(link_kind: LinkKind) {
+    match link_kind {
+        LinkKind::Static => println!("cargo:rustc-link-lib=static=hs"),
+        LinkKind::Dynamic => println!("cargo:rustc-link-lib=dylib=hs"),
+    }
+}
+
+fn detect_hyperscan_link_kind(lib_dirs: &[PathBuf]) -> LinkKind {
+    if lib_dirs
+        .iter()
+        .any(|lib_dir| lib_dir.join("libhs.a").is_file())
+    {
+        return LinkKind::Static;
+    }
+
+    if lib_dirs.iter().any(|lib_dir| {
+        [
+            "libhs.so",
+            "libhs.dylib",
+            "libhs.dll.a",
+            "hs.dll.lib",
+            "hs.lib",
+        ]
+        .iter()
+        .any(|lib_name| lib_dir.join(lib_name).is_file())
+    }) {
+        return LinkKind::Dynamic;
+    }
+
+    panic!(
+        "Could not find Vectorscan/Hyperscan library under HYPERSCAN_ROOT; expected libhs.a, libhs.so, libhs.dylib, libhs.dll.a, hs.dll.lib, or hs.lib"
+    );
 }
 
 fn link_cpp_runtime(target: &Target) {

--- a/vectorscan-rs-sys/build.rs
+++ b/vectorscan-rs-sys/build.rs
@@ -54,11 +54,6 @@ fn main() {
 
     let build = match std::env::var_os("HYPERSCAN_ROOT") {
         Some(hs_root) => build_existing_hyperscan(Path::new(&hs_root)),
-        None if target.is_windows() => {
-            panic!(
-                "HYPERSCAN_ROOT must point to an installed Vectorscan/Hyperscan prefix on Windows"
-            )
-        }
         None => build_vendored_vectorscan(&manifest_dir, &out_dir, &target),
     };
 
@@ -136,6 +131,8 @@ fn build_vendored_vectorscan(manifest_dir: &Path, out_dir: &Path, target: &Targe
 
     cfg_define_feature!("BUILD_UNIT", "unit_hyperscan");
     cfg_define_feature!("USE_CPU_NATIVE", "cpu_native");
+
+    configure_windows_cmake(&mut cfg, target);
 
     if cfg!(feature = "asan") {
         cfg.define("SANITIZE", "address");
@@ -217,6 +214,26 @@ fn build_vendored_vectorscan(manifest_dir: &Path, out_dir: &Path, target: &Targe
         lib_dirs: vec![dst.join("lib"), dst.join("lib64")],
         source_built: true,
         link_kind: LinkKind::Static,
+    }
+}
+
+fn configure_windows_cmake(cfg: &mut cmake::Config, target: &Target) {
+    if !target.is_windows() {
+        return;
+    }
+
+    if env("HOST").contains("windows") {
+        if target.env == "gnu" || target.is_windows_gnullvm() {
+            cfg.generator("MinGW Makefiles");
+        }
+
+        if target.is_windows_gnullvm() {
+            cfg.define("CMAKE_C_COMPILER", "clang")
+                .define("CMAKE_CXX_COMPILER", "clang++");
+        } else if target.env == "gnu" {
+            cfg.define("CMAKE_C_COMPILER", "gcc")
+                .define("CMAKE_CXX_COMPILER", "g++");
+        }
     }
 }
 

--- a/vectorscan-rs-sys/vectorscan/src/fdr/fdr_engine_description.cpp
+++ b/vectorscan-rs-sys/vectorscan/src/fdr/fdr_engine_description.cpp
@@ -71,7 +71,7 @@ u32 findDesiredStride(size_t num_lits, size_t min_len, size_t min_len_count) {
         } else if (num_lits < 5000) {
             // for larger but not huge sizes, go to stride 2 only if we have at
             // least minlen 3
-            desiredStride = std::min(min_len - 1, 2UL);
+            desiredStride = std::min(min_len - 1, size_t{2});
         }
     }
 

--- a/vectorscan-rs-sys/vectorscan/src/util/supervector/arch/x86/impl.cpp
+++ b/vectorscan-rs-sys/vectorscan/src/util/supervector/arch/x86/impl.cpp
@@ -42,12 +42,6 @@
 #if !(!defined(RELEASE_BUILD) && defined(FAT_RUNTIME) && (defined(HAVE_AVX2) || defined(HAVE_AVX512))) && defined(HAVE_SIMD_128_BITS)
 
 template<>
-really_inline SuperVector<16>::SuperVector(SuperVector const &other)
-{
-    u.v128[0] = other.u.v128[0];
-}
-
-template<>
 really_inline SuperVector<16>::SuperVector(typename base_type::type const v)
 {
     u.v128[0] = v;
@@ -580,12 +574,6 @@ really_inline SuperVector<16> SuperVector<16>::pshufb_maskz(SuperVector<16> b, u
 
 // 256-bit AVX2 implementation
 #if !(!defined(RELEASE_BUILD) && defined(FAT_RUNTIME) && defined(HAVE_AVX512)) && defined(HAVE_AVX2)
-
-template<>
-really_inline SuperVector<32>::SuperVector(SuperVector const &other)
-{
-    u.v256[0] = other.u.v256[0];
-}
 
 template<>
 really_inline SuperVector<32>::SuperVector(typename base_type::type const v)
@@ -1176,12 +1164,6 @@ really_inline SuperVector<32> SuperVector<32>::pshufb_maskz(SuperVector<32> b, u
 
 // 512-bit AVX512 implementation
 #if defined(HAVE_AVX512)
-
-template<>
-really_inline SuperVector<64>::SuperVector(SuperVector const &o)
-{
-    u.v512[0] = o.u.v512[0];
-}
 
 template<>
 really_inline SuperVector<64>::SuperVector(typename base_type::type const v)


### PR DESCRIPTION
## Summary

This PR adds Windows support for `vectorscan-rs-sys` and expands CI coverage for Windows targets.

Following review feedback, Windows builds now use the **vendored Vectorscan source by default**, the same as every other platform. `HYPERSCAN_ROOT` is no longer required on Windows — it remains available as an optional override for linking against an existing Vectorscan/Hyperscan installation.

The main changes are:

- Build the vendored Vectorscan source on Windows by default, with no `HYPERSCAN_ROOT` required.
- Support `x86_64-pc-windows-gnu` (MSYS2 MINGW64) and `aarch64-pc-windows-gnullvm` (MSYS2 CLANGARM64).
- Statically link the GNU/LLVM C++ runtime on Windows so the resulting binary has no MinGW runtime DLL dependencies.
- Add an optional `HYPERSCAN_ROOT` override for linking against an existing Vectorscan/Hyperscan installation.
- Add `HYPERSCAN_LINK_KIND=static|dynamic` to choose linkage explicitly when using `HYPERSCAN_ROOT`; otherwise auto-detect from what's present in the install.
- Add Windows CI coverage for release, test, and `cpu_native` builds on x86_64 and aarch64.
- Fix a Vectorscan FDR Windows compile error caused by a `std::min` `size_t` / `unsigned long` mismatch.
- Fix a Windows MinGW test-profile link error from duplicate `SuperVector` copy-constructor definitions in the vendored x86 implementation.
- Fix musl cross-compilation by supplying Vectorscan configure results for `unistd.h` and `posix_memalign`.
- Remove unused `flate2` and `tar` build dependencies.

## Default Build Flow

Without any environment variables, on every supported platform (Linux, macOS, Windows):

1. `cargo build` invokes `build.rs`.
2. `build.rs` runs CMake on the vendored Vectorscan source under `vectorscan-rs-sys/vectorscan/`.
3. The resulting static `libhs` is linked into the crate, along with the platform's C++ runtime.

On Windows specifically, `build.rs` selects the `MinGW Makefiles` generator and the matching `gcc`/`g++` or `clang`/`clang++` from the active MSYS2 environment, and links the GNU or LLVM C++ runtime statically.

## Optional `HYPERSCAN_ROOT` Override

Setting `HYPERSCAN_ROOT` switches the build script to link against an existing install instead of compiling the vendored source. This is useful for system packaging or when a downstream project already builds Vectorscan once and wants to share it across crates.

When `HYPERSCAN_ROOT` is set, the build script expects:

- headers under `$HYPERSCAN_ROOT/include`
- libraries under `$HYPERSCAN_ROOT/lib` or `$HYPERSCAN_ROOT/lib64`

Linkage selection:

- prefers static `libhs.a` when present
- falls back to dynamic / import libraries when only those are available
- accepts `HYPERSCAN_LINK_KIND=static` or `HYPERSCAN_LINK_KIND=dynamic` to choose explicitly

## Windows CI

This PR adds Windows CI jobs for:

- `windows-2025.x86_64.release`
- `windows-2025.x86_64.test`
- `windows-2025.x86_64.release.cpu_native`
- `windows-11.arm64.release`
- `windows-11.arm64.test`
- `windows-11.arm64.release.cpu_native`

CI installs the matching MSYS2 toolchain (MINGW64 or CLANGARM64) and runs `cargo build` / `cargo test` directly — no separate Vectorscan build step. For `cpu_native`, CI enables the `cpu_native` Cargo feature, which propagates `-DUSE_CPU_NATIVE=ON` to the vendored CMake build.

## Other Fixes

The Vectorscan FDR change updates:

```cpp
std::min(min_len - 1, 2UL)
```
to use matching `size_t` arguments. On Windows 64-bit, `size_t` and `unsigned long` are different widths, which can make `std::min` template deduction fail. The change preserves the existing stride selection behavior while allowing the code to compile on Windows.

The musl fix supplies `HAVE_UNISTD_H=1` and `HAVE_POSIX_MEMALIGN=1` for musl targets, which helps cross-compilation environments where Vectorscan's configure-time probes can miss those results.